### PR TITLE
Turn the "check" prop into a string | boolean

### DIFF
--- a/src/chessground.js
+++ b/src/chessground.js
@@ -10,7 +10,7 @@ export default class Chessground extends React.Component {
     fen: PropTypes.string,
     orientation: PropTypes.string,
     turnColor: PropTypes.string,
-    check: PropTypes.string,
+    check: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     lastMove: PropTypes.array,
     selected: PropTypes.string,
     coordinates: PropTypes.bool,


### PR DESCRIPTION
Consistent with the chessground config value: https://github.com/ornicar/chessground/blob/041baeb43796884b6d5742e414ffa70b79b8491d/src/config.ts#L11
(The above link shows the situation as of version 7.6.12, specified in react-chessground's package.json, and it hasn't changed in newer versions.)